### PR TITLE
Add documentation for NuFi wallet

### DIFF
--- a/src/Wallets.ts
+++ b/src/Wallets.ts
@@ -2,10 +2,12 @@ import Flint from "./wallets/Flint";
 import Gero from "./wallets/Gero";
 import Nami from "./wallets/Nami";
 import Cv from "./wallets/Cv";
+import Nufi from "./wallets/Nufi";
 
 export const Wallets = [
   Flint,
-  Nami, 
+  Nami,
   Cv, 
   Gero,
+  Nufi,
 ];

--- a/src/wallets/Nufi.ts
+++ b/src/wallets/Nufi.ts
@@ -1,0 +1,25 @@
+import { Api, SupportLevel } from "../system/Types";
+
+export default {
+  name: 'NuFi',
+  injectAs: 'nufi',
+  logo: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjIiIGhlaWdodD0iMjMiIHZpZXdCb3g9IjAgMCAyMiAyMyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iIzIxMjEyMSIgLz4KPHBhdGggZD0iTTQuMzA5OTkgOS4wMDAwOEM1LjMwODc3IDYuMjA0MDEgNy45ODA2OSA0LjIwMzA4IDExLjEyIDQuMjAzMDhDMTQuMjU5MiA0LjIwMzA4IDE2LjkzMTEgNi4yMDQwMSAxNy45Mjk5IDkuMDAwMDhDMTcuOTc5IDkuMTM3NDcgMTguMTA3NCA5LjIzMjE4IDE4LjI1MzMgOS4yMzIxOEgyMS4wNTk0QzIxLjI3MjUgOS4yMzIxOCAyMS40MzE3IDkuMDM1NzYgMjEuMzc5NCA4LjgyOTE5QzIwLjIxOTUgNC4yNDM2MiAxNi4wNjYgMC44NTAzNDIgMTEuMTIgMC44NTAzNDJDNi4xNzM5MSAwLjg1MDM0MiAyLjAyMDQyIDQuMjQzNjIgMC44NjA0NjggOC44MjkxOEMwLjgwODIxMyA5LjAzNTc2IDAuOTY3NDM0IDkuMjMyMTggMS4xODA1MiA5LjIzMjE4SDMuOTg2NTlDNC4xMzI0OSA5LjIzMjE4IDQuMjYwOTEgOS4xMzc0NyA0LjMwOTk5IDkuMDAwMDhaIiBmaWxsPSIjQzZGRjAwIi8+CjxwYXRoIGQ9Ik0zLjk4NjU5IDEzLjYzMjdDNC4xMzI0OSAxMy42MzI3IDQuMjYwOTEgMTMuNzI3NCA0LjMwOTk5IDEzLjg2NDhDNS4zMDg3NyAxNi42NjA4IDcuOTgwNjkgMTguNjYxOCAxMS4xMiAxOC42NjE4QzE0LjI1OTIgMTguNjYxOCAxNi45MzExIDE2LjY2MDggMTcuOTI5OSAxMy44NjQ4QzE3Ljk3OSAxMy43Mjc0IDE4LjEwNzQgMTMuNjMyNyAxOC4yNTMzIDEzLjYzMjdIMjEuMDU5NEMyMS4yNzI1IDEzLjYzMjcgMjEuNDMxNyAxMy44MjkxIDIxLjM3OTQgMTQuMDM1N0MyMC4yMTk1IDE4LjYyMTIgMTYuMDY2IDIyLjAxNDUgMTEuMTIgMjIuMDE0NUM2LjE3MzkxIDIyLjAxNDUgMi4wMjA0MiAxOC42MjEyIDAuODYwNDY4IDE0LjAzNTdDMC44MDgyMTMgMTMuODI5MSAwLjk2NzQzNCAxMy42MzI3IDEuMTgwNTIgMTMuNjMyN0gzLjk4NjU5WiIgZmlsbD0iI0M2RkYwMCIvPgo8cGF0aCBkPSJNOS4yNTQ5OSA5LjIzMjE4QzkuMDY5ODMgOS4yMzIxOCA4LjkxOTcyIDkuMzgyMjkgOC45MTk3MiA5LjU2NzQ2VjEzLjI5NzRDOC45MTk3MiAxMy40ODI1IDkuMDY5ODMgMTMuNjMyNyA5LjI1NDk5IDEzLjYzMjdIMTIuOTg0OUMxMy4xNzAxIDEzLjYzMjcgMTMuMzIwMiAxMy40ODI1IDEzLjMyMDIgMTMuMjk3NFY5LjU2NzQ2QzEzLjMyMDIgOS4zODIyOSAxMy4xNzAxIDkuMjMyMTggMTIuOTg0OSA5LjIzMjE4SDkuMjU0OTlaIiBmaWxsPSIjQzZGRjAwIi8+Cjwvc3ZnPgo=",
+  Apis: {
+    [Api.Enable]: SupportLevel.Supported,
+    [Api.IsEnabled]: SupportLevel.Supported,
+    [Api.ApiVersion]: SupportLevel.Supported,
+    [Api.Name]: SupportLevel.Supported,
+    [Api.Icon]: SupportLevel.Supported,
+    [Api.GetNetworkId]: SupportLevel.Supported,
+    [Api.GetUtxos]: SupportLevel.Supported,
+    [Api.GetBalance]: SupportLevel.Supported,
+    [Api.GetUsedAddresses]: SupportLevel.Supported,
+    [Api.GetUnusedAddresses]: SupportLevel.Supported,
+    [Api.GetChangeAddress]: SupportLevel.Supported,
+    [Api.GetRewardAddresses]: SupportLevel.Supported,
+    [Api.SignTx]: SupportLevel.Supported,
+    [Api.SignData]: SupportLevel.Supported,
+    [Api.SubmitTx]: SupportLevel.Supported,
+    [Api.GetCollateral]: SupportLevel.Experimental,
+  }
+}


### PR DESCRIPTION
NuFi (https://nu.fi) will besides the existing web wallet soon release also a webextension version implementing the CIP-0030 dApp connector for Cardano. The extension is currently being reviewed by Chrome Web Store so we expect it to be live sometime in the first half of June. Making this PR now to be ready when the extension is published.